### PR TITLE
A more compatible get_vbr() function.

### DIFF
--- a/system.asm
+++ b/system.asm
@@ -8,9 +8,34 @@ CIACRA_SPMODE 		= 1<<6
 INTREQ_PORTS		= 1<<3
 INTREQR_PORTS_BIT	= 3
 
+_AbsExecBase   = 4
+_LVOSupervisor = -30
+AttnFlags      = 296
+
 	section	code
+	public  _get_vbr
 	public	_level2_int
 	public	_keyboard_state
+	
+_get_vbr:
+	;; return current value of VBR in d0
+        movem.l a5/a6,-(SP)
+        moveq.l  #0,d0
+        move.l  _AbsExecBase,a6
+        move.w  AttnFlags(a6),d1
+        btst    #0,d1
+        beq.s   _get_vbr_Exit
+
+        lea     VBR_to_d0(PC),a5
+        jsr     _LVOSupervisor(a6)
+
+_get_vbr_Exit:
+	movem.l (SP)+,a5/a6
+        rts
+
+VBR_to_d0:
+        movec.l VBR,d0
+        rte
 
 _level2_int:
 	movem.l	d0-d1/a0-a2,-(sp)

--- a/system.c
+++ b/system.c
@@ -21,9 +21,9 @@
 
 // Defined in system.asm
 extern void level2_int();
+extern ULONG get_vbr();
 
 static void allow_task_switch(BOOL allow);
-static ULONG get_vbr();
 static void set_intreq(UWORD intreq);
 
 struct GfxBase* GfxBase;
@@ -386,18 +386,6 @@ static void allow_task_switch(BOOL allow) {
     Forbid();
     g.task_switch_disabled = TRUE;
   }
-}
-
-static ULONG get_vbr() {
-  // VBR is 0 on 68000, supervisor register on 68010+.
-  ULONG vbr = 0;
-
-  if (SysBase->AttnFlags & (1U << AFB_68010)) {
-    UWORD get_vbr_reg[] = {0x4E7A, 0x0801, 0x4E73}; // movec vbr,d0; rte
-    vbr = Supervisor((ULONG (*const)())get_vbr_reg);
-  }
-
-  return vbr;
 }
 
 static void set_intreq(UWORD intreq) {


### PR DESCRIPTION
The get_vbr() function implemented uses the C interface to call API function Supervisor().
This is not compatible with OS3.2.x (it crashes and reboots Amiga without a guru). This should be done using assembly.

Since the project already has a system.asm file, I've implemented a compatible _get_vbr:  in there and removed one in system.c.